### PR TITLE
Support Vernier LabPro via USB on Mac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target/
 .project
 .settings/
 .classpath
+.vscode

--- a/README.md
+++ b/README.md
@@ -3,62 +3,70 @@
 This is a set of Java libraries for communicating with various types of sensor interfaces that
 are typically used in schools.
 
-### Getting started
+### Local Installation
 
-This project uses maven for building. Most developement is done in Eclipse with the m2e plugin,
+This project uses maven for building. To build the project and install its JARs into the local repository, simply run:
+```
+mvn install
+```
+This is necessary for other projects that depend on JARs built by this project, such as the [SensorConnector](https://github.com/concord-consortium/sensor-connector) application.
+
+### Development
+
+Most development is done in Eclipse with the m2e plugin,
 but you should be able to work on it with just maven at the commandline or any IDE with maven support.
 
-The current place to get started is to look at the ExampleSensorApp class. You can subclass this
-and modify the deviceId and possibly openString in order to test out a specific device.
-The list of available 'deviceId's is in the DeviceID interface.
+The current place to get started is to look at the `ExampleSensorApp` class. You can subclass this
+and modify the `deviceId` and possibly `openString` in order to test out a specific device.
+The list of available `deviceId`s is in the `DeviceID` interface.
 
 If you don't have any hardware you can start with the PseudoSensorExampleApp which extends ExampleSensorApp.
 
 ### Architecture
 
-There code in the sensor sub project provides two APIs
+The code in the sensor sub project provides two APIs
 
-1. one for application developers to use sensors without writing vendor or device specific code
+1. one for application developers to use sensors without writing vendor- or device-specific code
 2. one to add support for a new device to the framework
 
-The main interface for both APIs is the org.concord.sensor.device.SensorDevice
+The main interface for both APIs is the `org.concord.sensor.device.SensorDevice`.
 There are javadocs in this interface describing how it is intended to be used.
 
 A summary of one way to use the application API goes like this:
 
-1. The Application uses a DeviceFactory to get an instance of a SensorDevice
-2. The Application creates a ExperientRequest consisting of one or more SensorRequests.
+1. The Application uses a `DeviceFactory` to get an instance of a `SensorDevice`
+2. The Application creates an `ExperimentRequest` consisting of one or more `SensorRequest`s.
    This describes what sensors and timing the Application wants to use.
-3. The Application calls SensorDevice#configure with this ExperimentRequest
-4. The SensorDevice implementation asks the hardware what sensors are actually attached,
-   compares it to the requested sensors, and then returns a ExperiementConfig that contains
-   the set of sensors which the SensorDevice feels is the best match for the request.
-   This ExperiementConfig also indicates if the SensorDevice thinks the config meets the
-   requirements of the request. So for example if the ExperimentRequest contains a temperature
-   sensor but no temperature sensor is attached, the returned ExperimentConfig should indicate
+3. The Application calls `SensorDevice#configure` with this `ExperimentRequest`
+4. The `SensorDevice` implementation asks the hardware what sensors are actually attached,
+   compares it to the requested sensors, and then returns an `ExperimentConfig` that contains
+   the set of sensors which the `SensorDevice` feels is the best match for the request.
+   This `ExperimentConfig` also indicates if the `SensorDevice` thinks the config meets the
+   requirements of the request. So, for example, if the `ExperimentRequest` contains a temperature
+   sensor but no temperature sensor is attached, the returned `ExperimentConfig` should indicate
    the requirements are not met.
-5. The Application then calls SensorDevice#start to start collecting data from the sensors
-   specified in the most recently returned ExperimentConfig.
-6. The Application calls SensorDevice#read again and again to get the resulting data.
-7. The Application calls SensorDevice#stop when it doesn't want to read anymore data.
+5. The Application then calls `SensorDevice#start` to start collecting data from the sensors
+   specified in the most recently returned `ExperimentConfig`.
+6. The Application calls `SensorDevice#read` again and again to get the resulting data.
+7. The Application calls `SensorDevice#stop` when it doesn't want to read any more data.
 
 
 ### TODO
 
-- move ftdi-serial-wrapper into its own repository, it isn't used by any of this code and could be a useful independent project for someone
+- move `ftdi-serial-wrapper` into its own repository, it isn't used by any of this code and could be a useful independent project for someone
 - get jars deployed to maven central
 - update documentation to make it really easy to try out by pulling jars from central
 - remove sensor native
 - make sure the native libraries are not loaded multiple times in a single jvm
-- make a command line app that lists the available devices, and runs the 2 tests on whichever device the user selects
+- make a command line app that lists the available devices, and runs the two tests on whichever device the user selects
 - move the matching of current configuration of sensors to a different API layer. This simplifies the
-  the implementation for the Vendors, and it also provides a simplier API for Application developers
+  implementation for the vendors, and it also provides a simplier API for application developers
 - update the API to support checking if a device is attached without actually opening it, also this API
   should support opening multiple devices of the same type attached to the same computer. Perhaps it would work to
-  have the DeviceFactory return a list of devices which aren't opened. These devices can then be queried to see
-  if they are actually available(they might be in use by us or some other program). And they can be opened. It is also nice
+  have the `DeviceFactory` return a list of devices which aren't opened. These devices can then be queried to see
+  if they are actually available (they might be in use by us or some other program). And they can be opened. It is also nice
   though to work without the device factory. So it might be best to introduce a 'Library' style object for each device.
-  So a GoIOLibrary sigleton can be created and this can be used to list the GoIO devices. The DeviceFactory can use this.
-- boil DeviceService down to just logging and user messages, the rest of the methods can be removed or made static, they
+  So a `GoIOLibrary` singleton can be created and this can be used to list the GoIO devices. The `DeviceFactory` can use this.
+- boil `DeviceService` down to just logging and user messages, the rest of the methods can be removed or made static, they
   are legacy for Waba support
-- Move DeviceFactory out of this library and make the creation of devices more like 'new SomethingDevice(deviceService, optional_type)'
+- Move `DeviceFactory` out of this library and make the creation of devices more like `new SomethingDevice(deviceService, optional_type)`

--- a/pom.xml
+++ b/pom.xml
@@ -9,25 +9,6 @@
   <name>Sensor Projects</name>
   <description> A parent for all sensor specific projects </description>
 
-  <distributionManagement>
-    <repository>
-      <id>cc-dist-repo-internal</id>
-      <name>Concord Consortium Internal</name>
-      <url>scpexe://source.concord.org/web/source.concord.org/html/software/maven2/internal/</url>
-    </repository>
-    <snapshotRepository>
-      <id>cc-dist-repo-internal-snapshot</id>
-      <name>Concord Consortium Internal Snapshot</name>
-      <uniqueVersion>true</uniqueVersion>
-      <url>scpexe://source.concord.org/web/source.concord.org/html/software/maven2/internal_snapshot/</url>
-    </snapshotRepository>
-    <site> 
-      <id>cc-dist-site</id>
-      <name>Concord Consortium Maven2 Website</name>
-      <url>scpexe://source.concord.org/web/source.concord.org/html/software/maven2/site/</url>
-    </site>
-  </distributionManagement>
-  
   <modules>
     <module>ftdi-serial-wrapper</module>
     <module>goio-jna</module>

--- a/sensor-native/src/java/org/concord/sensor/nativelib/NativePseudoSensorDevice.java
+++ b/sensor-native/src/java/org/concord/sensor/nativelib/NativePseudoSensorDevice.java
@@ -202,6 +202,23 @@ public class NativePseudoSensorDevice
 	}
 
 	/**
+	 * @see org.concord.sensor.device.SensorDevice#supportsChannelPolling()
+	 */
+	public boolean supportsChannelPolling() 
+	{
+		return false;
+	}
+
+	/**
+	 * @see org.concord.sensor.device.SensorDevice#pollChannelValues()
+	 */
+	public int pollChannelValues(org.concord.sensor.ExperimentConfig expConfig, float [] values)
+	{
+		// not supported
+		return -1;
+	}
+
+	/**
 	 * 
 	 * native. but with the associated cookie.  unless there is another
 	 * perhaps the cookie can be stored in this object so the native code

--- a/sensor-native/src/java/org/concord/sensor/nativelib/NativeTISensorDevice.java
+++ b/sensor-native/src/java/org/concord/sensor/nativelib/NativeTISensorDevice.java
@@ -201,6 +201,23 @@ public class NativeTISensorDevice
 	}
 
 	/**
+	 * @see org.concord.sensor.device.SensorDevice#supportsChannelPolling()
+	 */
+	public boolean supportsChannelPolling() 
+	{
+		return false;
+	}
+
+	/**
+	 * @see org.concord.sensor.device.SensorDevice#pollChannelValues()
+	 */
+	public int pollChannelValues(org.concord.sensor.ExperimentConfig expConfig, float [] values)
+	{
+		// not supported
+		return -1;
+	}
+
+	/**
 	 * 
 	 * native. but with the associated cookie.  unless there is another
 	 * perhaps the cookie can be stored in this object so the native code

--- a/sensor-native/src/java/org/concord/sensor/nativelib/NativeVernierSensorDevice.java
+++ b/sensor-native/src/java/org/concord/sensor/nativelib/NativeVernierSensorDevice.java
@@ -215,6 +215,23 @@ public class NativeVernierSensorDevice
 	}
 
 	/**
+	 * @see org.concord.sensor.device.SensorDevice#supportsChannelPolling()
+	 */
+	public boolean supportsChannelPolling() 
+	{
+		return false;
+	}
+
+	/**
+	 * @see org.concord.sensor.device.SensorDevice#pollChannelValues()
+	 */
+	public int pollChannelValues(org.concord.sensor.ExperimentConfig expConfig, float [] values)
+	{
+		// not supported
+		return -1;
+	}
+
+	/**
 	 * 
 	 * native. but with the associated cookie.  unless there is another
 	 * perhaps the cookie can be stored in this object so the native code

--- a/sensor-native/src/swig/java/ccsd/pseudo/ExperimentConfig.java
+++ b/sensor-native/src/swig/java/ccsd/pseudo/ExperimentConfig.java
@@ -37,6 +37,7 @@ public class ExperimentConfig implements
  {
   private long swigCPtr;
   protected boolean swigCMemOwn;
+  private int initialReadDelayMillis;
 
   protected ExperimentConfig(long cPtr, boolean cMemoryOwn) {
     swigCMemOwn = cMemoryOwn;
@@ -68,6 +69,16 @@ public class ExperimentConfig implements
 	{
 		return getExactPeriodUChar() == 1;
 	}
+	
+  public int getInitialReadDelay()
+  {
+    return initialReadDelayMillis;
+  }
+
+  public void setInitialReadDelay(int initialReadDelayMillis)
+  {
+    this.initialReadDelayMillis = initialReadDelayMillis;
+  }
 	
 	public org.concord.sensor.SensorConfig [] getSensorConfigs()
 	{

--- a/sensor-native/src/swig/java/ccsd/ti/ExperimentConfig.java
+++ b/sensor-native/src/swig/java/ccsd/ti/ExperimentConfig.java
@@ -37,6 +37,7 @@ public class ExperimentConfig implements
  {
   private long swigCPtr;
   protected boolean swigCMemOwn;
+  private int initialReadDelayMillis;
 
   protected ExperimentConfig(long cPtr, boolean cMemoryOwn) {
     swigCMemOwn = cMemoryOwn;
@@ -136,6 +137,16 @@ public class ExperimentConfig implements
     return NativeBridgeJNI.get_ExperimentConfig_deviceName(swigCPtr);
   }
 
+  public int getInitialReadDelay()
+  {
+    return initialReadDelayMillis;
+  }
+
+  public void setInitialReadDelay(int initialReadDelayMillis)
+  {
+    this.initialReadDelayMillis = initialReadDelayMillis;
+  }
+	
   public void setNumSensorConfigs(int numSensorConfigs) {
     NativeBridgeJNI.set_ExperimentConfig_numSensorConfigs(swigCPtr, numSensorConfigs);
   }

--- a/sensor-native/src/swig/java/ccsd/vernier/ExperimentConfig.java
+++ b/sensor-native/src/swig/java/ccsd/vernier/ExperimentConfig.java
@@ -37,10 +37,12 @@ public class ExperimentConfig implements
  {
   private long swigCPtr;
   protected boolean swigCMemOwn;
+  private int initialReadDelayMillis;
 
   protected ExperimentConfig(long cPtr, boolean cMemoryOwn) {
     swigCMemOwn = cMemoryOwn;
     swigCPtr = cPtr;
+    initialReadDelayMillis = 0;
   }
 
   protected void finalize() {
@@ -67,7 +69,17 @@ public class ExperimentConfig implements
 	public boolean getExactPeriod()
 	{
 		return getExactPeriodUChar() == 1;
-	}
+  }
+  
+  public int getInitialReadDelay()
+  {
+    return initialReadDelayMillis;
+  }
+
+  public void setInitialReadDelay(int initialReadDelayMillis)
+  {
+    this.initialReadDelayMillis = initialReadDelayMillis;
+  }
 	
 	public org.concord.sensor.SensorConfig [] getSensorConfigs()
 	{

--- a/sensor-vernier/pom.xml
+++ b/sensor-vernier/pom.xml
@@ -52,6 +52,7 @@
         <configuration>
           <excludes>
             <!-- don't run any of the tests automatically because they require the correct hardware to be attached -->
+            <!-- to run a test, comment out its <exclude> line -->
             <exclude>org/concord/sensor/vernier/goio/**</exclude>
             <exclude>org/concord/sensor/vernier/labpro/**</exclude>
             <exclude>org/concord/sensor/vernier/labquest/**</exclude>

--- a/sensor-vernier/pom.xml
+++ b/sensor-vernier/pom.xml
@@ -52,7 +52,9 @@
         <configuration>
           <excludes>
             <!-- don't run any of the tests automatically because they require the correct hardware to be attached -->
-            <exclude>org/concord/sensor/vernier/**</exclude>
+            <exclude>org/concord/sensor/vernier/goio/**</exclude>
+            <exclude>org/concord/sensor/vernier/labpro/**</exclude>
+            <exclude>org/concord/sensor/vernier/labquest/**</exclude>
           </excludes>
         </configuration>
       </plugin>

--- a/sensor-vernier/src/main/java/org/concord/sensor/vernier/labpro/LabProProtocol.java
+++ b/sensor-vernier/src/main/java/org/concord/sensor/vernier/labpro/LabProProtocol.java
@@ -96,6 +96,13 @@ public class LabProProtocol
 		sendCommand(LabProProtocol.CMD.REQUEST_CHANNEL_STATUS, "" + channel + ",0");
 	}
 
+	// Note: Must set up channel ("s{1,...}") before requesting channel data
+	public void requestChannelData(int channel)
+	    throws SerialException
+	{
+		sendCommand(LabProProtocol.CMD.REQUEST_CHANNEL_DATA, "" + channel + ",0");
+	}
+
 	public void channelSetup(int channel, int operation) 
 		throws SerialException
 	{
@@ -147,11 +154,9 @@ public class LabProProtocol
 		throws SerialException
 	{
 		if(PRINT_SENDS){
-			System.out.println("s");
+			System.out.print("sending: " + "s\n");
 		}
 		labProDevice.getPort().write(wakeUpBytes);
 		labProDevice.getDeviceService().sleep(100);
 	}
-	
-
 }

--- a/sensor-vernier/src/main/java/org/concord/sensor/vernier/labpro/LabProSensorDevice.java
+++ b/sensor-vernier/src/main/java/org/concord/sensor/vernier/labpro/LabProSensorDevice.java
@@ -33,10 +33,10 @@ public class LabProSensorDevice extends AbstractStreamingSensorDevice
 	
     public final static int [] CHANNELS = {1,2,3,4,11,12};
 
-		public final static String ERR_DEVICE_NOT_ATTACHED = "LabPro is not attached";
+	public final static String ERR_DEVICE_NOT_ATTACHED = "LabPro is not attached";
 
-		// additional delay from starting an experiment to reading first sample
-		public final static int INITIAL_READ_DELAY_MILLIS = 850;
+	// additional delay from starting an experiment to reading first sample
+	public final static int INITIAL_READ_DELAY_MILLIS = 850;
     
 	protected final byte [] buf = new byte [1024];
 	
@@ -177,10 +177,6 @@ public class LabProSensorDevice extends AbstractStreamingSensorDevice
 
 		// Configure the LabPro-specific timing delay
 		experimentConfig.setInitialReadDelay(INITIAL_READ_DELAY_MILLIS);
-
-		// Configure the LabPro library appropriately
-		int numChannels = experimentConfig.getSensorConfigs().length;
-		port.setNumChannels(numChannels);
 
 		return experimentConfig;
 	}

--- a/sensor-vernier/src/main/java/org/concord/sensor/vernier/labpro/LabProSensorDevice.java
+++ b/sensor-vernier/src/main/java/org/concord/sensor/vernier/labpro/LabProSensorDevice.java
@@ -342,7 +342,8 @@ public class LabProSensorDevice extends AbstractStreamingSensorDevice
 		int returnValueCount = 0;
 		try {
 			SensorConfig[] sensorConfigs = expConfig.getSensorConfigs();
-			for(int i=0; i < sensorConfigs.length; i++) {
+			int sensorCount = sensorConfigs != null ? sensorConfigs.length : 0;
+			for(int i=0; i < sensorCount; i++) {
 				SensorConfig sensorConfig = sensorConfigs[i];
 				int sensorChannel = sensorConfig.getPort();
 				// must set up channel before reading data

--- a/sensor-vernier/src/main/java/org/concord/sensor/vernier/labpro/LabProSensorDevice.java
+++ b/sensor-vernier/src/main/java/org/concord/sensor/vernier/labpro/LabProSensorDevice.java
@@ -405,15 +405,15 @@ public class LabProSensorDevice extends AbstractStreamingSensorDevice
     	throws SerialException
 	{
 		// read one byte at a time until we get to the closing bracket
-		// this is not the best way to do this, but it work without blocking
-		// regardless about how the readBytes on the port is implemented
+		// this is not the best way to do this, but it works without blocking
+		// regardless of how the readBytes on the port is implemented
 		// The timeout here should be set depending on how long it takes
 		// the LabPro to get back to us with the first byte
-		// check that the first byte is a }		
 		if((sb.totalBytes - sb.processedBytes) < 2){
 			return 0;
 		}
 		
+		// check that the first byte is a '{'
 		byte currentByte = sb.buf[sb.processedBytes];
 		if(currentByte != '{'){
 			log("First byte isn't { instead it is: " + (char)currentByte);
@@ -455,9 +455,13 @@ public class LabProSensorDevice extends AbstractStreamingSensorDevice
 		String result = 
 			new String(sb.buf, sb.processedBytes, off-sb.processedBytes);
 
+		// optional logging should have an option in the logging
+		// system so this can be turned on and off
+		log("read: " + result);
+		
 		// now we have to use basic string parsing because waba and java don't 
 		// share the tokenizer
-		// but sense we are in a crunch lets just use the java conventions
+		// but since we are in a crunch let's just use the java conventions
 		// and deal with the waba stuff when we need it.
 		int count = 0;
 		StringTokenizer toks = new StringTokenizer(result, "{},\r\n");
@@ -478,7 +482,7 @@ public class LabProSensorDevice extends AbstractStreamingSensorDevice
 	}
 	
 	/**
-	 * This read the string return values of the LabPro
+	 * This reads the string return values of the LabPro
 	 * These values look like:
 	 * {  +2.40000E+01, -9.99900E+02, -9.99900E+02 }
 	 * @param values
@@ -489,11 +493,10 @@ public class LabProSensorDevice extends AbstractStreamingSensorDevice
 		throws SerialException
 	{
 		// read one byte at a time until we get to the closing bracket
-		// this is not the best way to do this, but it work without blocking
-		// regardless about how the readBytes on the port is implemented
+		// this is not the best way to do this, but it works without blocking
+		// regardless of how the readBytes on the port is implemented
 		// The timeout here should be set depending on how long it takes
 		// the LabPro to get back to us with the first byte
-		// check that the first byte is a }		
 
 		// It ought to be faster to read a whole chunk of bytes until the last
 		// byte read is }
@@ -502,8 +505,8 @@ public class LabProSensorDevice extends AbstractStreamingSensorDevice
 		int numBytes = 0;
 		int attempts = 0;
 		while(attempts < 5){
-			// give it 100ms to send the reponse
-			ret = port.readBytes(buf, off, buf.length-off, 100);		
+			// give it 100ms to send the response
+			ret = port.readBytesUntil(buf, off, buf.length-off, 100, '\n');
 			if(ret < 0){
 				log("error reading values err: " + ret);
 				return -1;
@@ -548,14 +551,14 @@ public class LabProSensorDevice extends AbstractStreamingSensorDevice
 
 		// optional logging should have an option in the logging
 		// system so this can be turned on and off
-		log("read: \"" + result + "\"");
+		log("read: " + result);
 		
 		// We should use basic string parsing because waba and java don't 
 		// share a common tokenizer class
 		// but since we are in a time crunch lets just use the java conventions
 		// and deal with the waba stuff when we need it.
 		
-		// first find the last occurance of { that way we can 
+		// first find the last occurrence of '{' that way we can 
 		// skip any junk that came with this. 
 		int startingIndex = result.lastIndexOf("{");
 		

--- a/sensor-vernier/src/main/java/org/concord/sensor/vernier/labpro/LabProSensorDevice.java
+++ b/sensor-vernier/src/main/java/org/concord/sensor/vernier/labpro/LabProSensorDevice.java
@@ -33,7 +33,10 @@ public class LabProSensorDevice extends AbstractStreamingSensorDevice
 	
     public final static int [] CHANNELS = {1,2,3,4,11,12};
 
-    public final static String ERR_DEVICE_NOT_ATTACHED = "LabPro is not attached";
+		public final static String ERR_DEVICE_NOT_ATTACHED = "LabPro is not attached";
+
+		// additional delay from starting an experiment to reading first sample
+		public final static int INITIAL_READ_DELAY_MILLIS = 850;
     
 	protected final byte [] buf = new byte [1024];
 	
@@ -169,15 +172,18 @@ public class LabProSensorDevice extends AbstractStreamingSensorDevice
      * @see org.concord.sensor.device.SensorDevice#configure(org.concord.sensor.ExperimentRequest)
      */
     public ExperimentConfig configure(ExperimentRequest request) 
-    {
+	{
 		ExperimentConfig experimentConfig = autoIdConfigure(request);
+
+		// Configure the LabPro-specific timing delay
+		experimentConfig.setInitialReadDelay(INITIAL_READ_DELAY_MILLIS);
 
 		// Configure the LabPro library appropriately
 		int numChannels = experimentConfig.getSensorConfigs().length;
 		port.setNumChannels(numChannels);
 
 		return experimentConfig;
-    }
+	}
 
 
 	/**
@@ -389,12 +395,12 @@ public class LabProSensorDevice extends AbstractStreamingSensorDevice
 				} else if(sensor.getType() == SensorConfig.QUANTITY_RAW_VOLTAGE_2 ||
 						sensor.getType() == SensorConfig.QUANTITY_RAW_DATA_2){
 					// setup sensor to report +/-10V
-					protocol.channelSetup(channelNumber, 2);				
+					protocol.channelSetup(channelNumber, 2);
 				} else {
 					protocol.channelSetup(channelNumber, 1);
-				}				
-			}			
-			
+				}
+			}
+
 			port.setNumChannels(sensorConfigs.length);
 			
 			// Turning on the power seems necessary before reading
@@ -439,7 +445,7 @@ public class LabProSensorDevice extends AbstractStreamingSensorDevice
 			// send the reset
 			protocol.reset();
 			port.reset();
-						
+
 			// Close the port if it can open quickly again.
 			// This way if the program crashes or second program is opened then there will
 			// be less of a chance of port conflict.

--- a/sensor-vernier/src/main/java/org/concord/sensor/vernier/labquest/LabQuestSensorDevice.java
+++ b/sensor-vernier/src/main/java/org/concord/sensor/vernier/labquest/LabQuestSensorDevice.java
@@ -109,7 +109,7 @@ public class LabQuestSensorDevice extends AbstractSensorDevice
 			labQuestLibrary = null;
 			labQuest = null;
 		} catch (LabQuestException e) {
-			e.printStackTrace();
+			// e.printStackTrace();
 			// set it to null even if we have an exception because that is the 
 			// indication that the device is not attached
 			labQuest = null;
@@ -131,15 +131,15 @@ public class LabQuestSensorDevice extends AbstractSensorDevice
 		if(labQuest == null){
 			return false;
 		}
+
 		try {
 			labQuest.getStatus();
-		} catch(LabQuestException e){
-			if (e.isCommunicationError()){
-				return false;
-			}
+		} catch(Exception e){
+			return false;
 		}
 
-		return true;
+		// errors can set it to null
+		return labQuest != null;
 	}
 	
 	public LabQuest getCurrentLabQuest() {

--- a/sensor-vernier/src/test/java/org/concord/sensor/vernier/goio/GoIOSensorDeviceTest.java
+++ b/sensor-vernier/src/test/java/org/concord/sensor/vernier/goio/GoIOSensorDeviceTest.java
@@ -22,8 +22,11 @@ public class GoIOSensorDeviceTest extends SensorDeviceTest {
 	
 	@Test
 	public void testRepeatGetCurrentConfig(){
-		JOptionPane.showMessageDialog(null, "Attach the " + getDeviceLabel() +
-			" and no sensor");
+		org.junit.Assume.assumeTrue(deviceAttachedResponse == JOptionPane.YES_OPTION);
+
+		deviceAttachedResponse = JOptionPane.showConfirmDialog(null, "Attach the " + getDeviceLabel()
+															+ " and no sensor", "", JOptionPane.YES_NO_OPTION);
+		org.junit.Assume.assumeTrue(deviceAttachedResponse == JOptionPane.YES_OPTION);
 
 		prepareDevice();
 		
@@ -36,9 +39,10 @@ public class GoIOSensorDeviceTest extends SensorDeviceTest {
 		
 		// The force sensor is used here because it is a smart sensor that has a DDS record
 		// stored in the sensor.  The temperature sensor does not have a DDS record.
-		JOptionPane.showMessageDialog(null, "Attach the " + getDeviceLabel() +
-		" and a force sensor");
-		
+		int response = JOptionPane.showConfirmDialog(null, "Attach the " + getDeviceLabel()
+										+ " and a force sensor", "", JOptionPane.YES_NO_OPTION);
+		org.junit.Assume.assumeTrue(response == JOptionPane.YES_OPTION);
+
 		experimentConfig = device.getCurrentConfig();
 		assertNotNull("Non null experiment config", experimentConfig);
 		assertEquals("Force sensor", SensorConfig.QUANTITY_FORCE,
@@ -52,11 +56,14 @@ public class GoIOSensorDeviceTest extends SensorDeviceTest {
 
 	@Test
 	public void testRawVoltage2Collection() throws InterruptedException{
+		org.junit.Assume.assumeTrue(deviceAttachedResponse == JOptionPane.YES_OPTION);
+
 		// This isn't a good test because the 10V channel doesn't report a 
 		// very different value from the 5V channel.  This test would require
 		// the actual header.
-		JOptionPane.showMessageDialog(null, "Attach the " + getDeviceLabel() +
-		" and a temperature sensor");
+		int response = JOptionPane.showConfirmDialog(null, "Attach the " + getDeviceLabel() +
+										" and a temperature sensor", "", JOptionPane.YES_NO_OPTION);
+		org.junit.Assume.assumeTrue(response == JOptionPane.YES_OPTION);
 
 		prepareDevice();
 

--- a/sensor-vernier/src/test/java/org/concord/sensor/vernier/goio/GoIOSensorDeviceTest.java
+++ b/sensor-vernier/src/test/java/org/concord/sensor/vernier/goio/GoIOSensorDeviceTest.java
@@ -24,8 +24,8 @@ public class GoIOSensorDeviceTest extends SensorDeviceTest {
 	public void testRepeatGetCurrentConfig(){
 		org.junit.Assume.assumeTrue(deviceAttachedResponse == JOptionPane.YES_OPTION);
 
-		deviceAttachedResponse = JOptionPane.showConfirmDialog(null, "Attach the " + getDeviceLabel()
-															+ " and no sensor", "", JOptionPane.YES_NO_OPTION);
+		String deviceAloneMsg = "Attach the " + getDeviceLabel() + " and no sensor";
+		deviceAttachedResponse = JOptionPane.showConfirmDialog(null, deviceAloneMsg, "", JOptionPane.YES_NO_OPTION);
 		org.junit.Assume.assumeTrue(deviceAttachedResponse == JOptionPane.YES_OPTION);
 
 		prepareDevice();
@@ -39,8 +39,8 @@ public class GoIOSensorDeviceTest extends SensorDeviceTest {
 		
 		// The force sensor is used here because it is a smart sensor that has a DDS record
 		// stored in the sensor.  The temperature sensor does not have a DDS record.
-		int response = JOptionPane.showConfirmDialog(null, "Attach the " + getDeviceLabel()
-										+ " and a force sensor", "", JOptionPane.YES_NO_OPTION);
+		String withForceMsg = "Attach the " + getDeviceLabel() + " and a force sensor";
+		int response = JOptionPane.showConfirmDialog(null, withForceMsg, "", JOptionPane.YES_NO_OPTION);
 		org.junit.Assume.assumeTrue(response == JOptionPane.YES_OPTION);
 
 		experimentConfig = device.getCurrentConfig();
@@ -61,8 +61,8 @@ public class GoIOSensorDeviceTest extends SensorDeviceTest {
 		// This isn't a good test because the 10V channel doesn't report a 
 		// very different value from the 5V channel.  This test would require
 		// the actual header.
-		int response = JOptionPane.showConfirmDialog(null, "Attach the " + getDeviceLabel() +
-										" and a temperature sensor", "", JOptionPane.YES_NO_OPTION);
+		String withTempMsg = "Attach the " + getDeviceLabel() + " and a temperature sensor";
+		int response = JOptionPane.showConfirmDialog(null, withTempMsg, "", JOptionPane.YES_NO_OPTION);
 		org.junit.Assume.assumeTrue(response == JOptionPane.YES_OPTION);
 
 		prepareDevice();

--- a/sensor-vernier/src/test/java/org/concord/sensor/vernier/labquest/TestLabQuestDevice.java
+++ b/sensor-vernier/src/test/java/org/concord/sensor/vernier/labquest/TestLabQuestDevice.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 
 public class TestLabQuestDevice
 {
+	/*
 	@Test
 	public void testTemperatureAndLight(){
 		ExampleSensorApp app = new ExampleSensorApp(){
@@ -17,4 +18,5 @@ public class TestLabQuestDevice
 		};
 		app.testAllConnectedProbes();
 	}
+	*/
 }

--- a/sensor/src/main/java/org/concord/sensor/ExperimentConfig.java
+++ b/sensor/src/main/java/org/concord/sensor/ExperimentConfig.java
@@ -106,15 +106,6 @@ public interface ExperimentConfig
 	public int getInitialReadDelay();
 		
 	/**
-	 * This is the number of milliseconds the client should wait between
-	 * starting an experiment and beginning to collect the data in
-	 * addition to the time it takes to collect the first sample.
-	 * 
-	 * @return
-	 */
-	public void setInitialReadDelay(int initialReadDelayMillis);
-		
-	/**
 	 * An array of SensorConfig, each SensorConfig contains configuration
 	 * information about the sensor.  This will return null if there are no
 	 * sensor configs.  Zero length arrays are not handled by waba which is 

--- a/sensor/src/main/java/org/concord/sensor/ExperimentConfig.java
+++ b/sensor/src/main/java/org/concord/sensor/ExperimentConfig.java
@@ -97,6 +97,24 @@ public interface ExperimentConfig
 	public float getDataReadPeriod();
 		
 	/**
+	 * This is the number of milliseconds the client should wait between
+	 * starting an experiment and beginning to collect the data in
+	 * addition to the time it takes to collect the first sample.
+	 * 
+	 * @return
+	 */
+	public int getInitialReadDelay();
+		
+	/**
+	 * This is the number of milliseconds the client should wait between
+	 * starting an experiment and beginning to collect the data in
+	 * addition to the time it takes to collect the first sample.
+	 * 
+	 * @return
+	 */
+	public void setInitialReadDelay(int initialReadDelayMillis);
+		
+	/**
 	 * An array of SensorConfig, each SensorConfig contains configuration
 	 * information about the sensor.  This will return null if there are no
 	 * sensor configs.  Zero length arrays are not handled by waba which is 

--- a/sensor/src/main/java/org/concord/sensor/device/SensorDevice.java
+++ b/sensor/src/main/java/org/concord/sensor/device/SensorDevice.java
@@ -109,7 +109,7 @@ public interface SensorDevice
 	 * object will be created instead.
 	 */
 	public void close();
-	
+
 	/**
 	 * This method is called after open but before start.  The request is 
 	 * a general sensor configuration request.  The device should try to
@@ -223,4 +223,24 @@ public interface SensorDevice
 	 * @return
 	 */
 	public ExperimentConfig getCurrentConfig();
+
+	/**
+	 * Whether the device supports polling individual channel values without 
+	 * setting up a full-blown experiment collection.
+	 * 
+	 * @return
+	 */
+	public boolean supportsChannelPolling();
+	
+	/**
+	 * Returns sensor values for the channels specified in 'channels',
+	 * and returns them in the 'values' array.
+	 * Return value is the number of values returned (generally the
+	 * number of channels requested) or an error value.
+	 * 
+	 * @param channels
+	 * @param values
+	 * @return
+	 */
+	public int pollChannelValues(ExperimentConfig channels, float [] values);
 }

--- a/sensor/src/main/java/org/concord/sensor/device/impl/AbstractSensorDevice.java
+++ b/sensor/src/main/java/org/concord/sensor/device/impl/AbstractSensorDevice.java
@@ -576,6 +576,25 @@ public abstract class AbstractSensorDevice implements SensorDevice,
 	}
 	
 	/**
+	 * Subclasses should override this method if they support polling individual
+	 * channel values without setting up a full-blown experiment collection.
+	 * 
+	 * @return
+	 */
+	public boolean supportsChannelPolling() {
+		return false;
+	}
+	
+	/**
+	 * Subclasses should override this method if they support polling individual
+	 * channel values without setting up a full-blown experiment collection.
+	 */
+	public int pollChannelValues(ExperimentConfig channels, float [] values) {
+		// not supported by default
+		return -1;
+	}
+
+	/**
 	 * This method is called after the port has been setup with the
 	 * serialPortParams returned by getSerialPortParams and then opened with
 	 * this portName.

--- a/sensor/src/main/java/org/concord/sensor/device/impl/AbstractStreamingSensorDevice.java
+++ b/sensor/src/main/java/org/concord/sensor/device/impl/AbstractStreamingSensorDevice.java
@@ -43,7 +43,7 @@ public abstract class AbstractStreamingSensorDevice extends AbstractSensorDevice
 		// assume there is something wrong with the port.
 		int ret = -1;
 
-        try {
+		try {
             ret = port.readBytes(streamingBuffer.buf, 
             		streamingBuffer.totalBytes,
             		readSize - streamingBuffer.totalBytes, 1);
@@ -78,6 +78,7 @@ public abstract class AbstractStreamingSensorDevice extends AbstractSensorDevice
         
         streamingBuffer.shift();
 
+        // System.out.println("AbstractStreamingSensorDevice.read [end] numSamples: " + numSamples);
         return numSamples;
 	}
 	

--- a/sensor/src/main/java/org/concord/sensor/impl/ExperimentConfigImpl.java
+++ b/sensor/src/main/java/org/concord/sensor/impl/ExperimentConfigImpl.java
@@ -49,9 +49,15 @@ public class ExperimentConfigImpl
     private String deviceName;
 	private int deviceId;
     private float dataReadPeriod;
+	private int initialReadDelayMillis;
 
     private Range periodRange;
-    
+	
+	public ExperimentConfigImpl()
+	{
+		initialReadDelayMillis = 0;
+	}
+
 	/* (non-Javadoc)
 	 * @see org.concord.sensor.ExperimentConfig#isValid()
 	 */
@@ -102,8 +108,18 @@ public class ExperimentConfigImpl
 	{
 	    exactPeriod = exact;
 	}
-	
-	/* (non-Javadoc)
+
+	public int getInitialReadDelay()
+	{
+	  return initialReadDelayMillis;
+	}
+  
+	public void setInitialReadDelay(int initialReadDelayMillis)
+	{
+	  this.initialReadDelayMillis = initialReadDelayMillis;
+	}
+	  
+	  /* (non-Javadoc)
 	 * @see org.concord.sensor.ExperimentConfig#getSensorConfigs()
 	 */
 	public SensorConfig[] getSensorConfigs() 

--- a/sensor/src/main/java/org/concord/sensor/serial/SensorSerialPort.java
+++ b/sensor/src/main/java/org/concord/sensor/serial/SensorSerialPort.java
@@ -62,6 +62,8 @@ public interface SensorSerialPort
 		throws SerialException;
 	
 	public boolean isOpen();
+
+	public void reset();
 	
 	public abstract void setSerialPortParams( int baud, int data, 
             int stop, int parity )
@@ -79,6 +81,8 @@ public interface SensorSerialPort
 	
     public abstract void enableReceiveTimeout( int time )
 		throws SerialException;
+
+	public abstract void setNumChannels(int numChannels);
 
 	/**
 	 * The read method on input stream does not handle the timeout 
@@ -101,7 +105,7 @@ public interface SensorSerialPort
 	 */
 	public int readBytes(byte [] buf, int off, int len, long timeout)
 		throws SerialException;
-    
+		
 		public static final int NO_TERMINATE_BYTE = 0xFF00;
 		
 		public int readBytesUntil(byte [] buf, int off, int len, long timeout, int terminateByte)

--- a/sensor/src/main/java/org/concord/sensor/serial/SensorSerialPort.java
+++ b/sensor/src/main/java/org/concord/sensor/serial/SensorSerialPort.java
@@ -87,8 +87,8 @@ public interface SensorSerialPort
 	 * set to len bytes.  In this method the threshold is always len
 	 * bytes.
 	 * 
-	 * The thresold is the minimum number of bytes that need to be read
-	 * before the method returns.  If this is minimum number is not read
+	 * The threshold is the minimum number of bytes that need to be read
+	 * before the method returns.  If this minimum number is not read
 	 * before the timeout then the method returns the number read
 	 * at that point.   
 	 * 
@@ -101,6 +101,11 @@ public interface SensorSerialPort
 	 */
 	public int readBytes(byte [] buf, int off, int len, long timeout)
 		throws SerialException;
+    
+		public static final int NO_TERMINATE_BYTE = 0xFF00;
+		
+		public int readBytesUntil(byte [] buf, int off, int len, long timeout, int terminateByte)
+			throws SerialException;
     
     public void write(int value)
         throws SerialException;

--- a/sensor/src/main/java/org/concord/sensor/serial/SensorSerialPort.java
+++ b/sensor/src/main/java/org/concord/sensor/serial/SensorSerialPort.java
@@ -105,12 +105,12 @@ public interface SensorSerialPort
 	 */
 	public int readBytes(byte [] buf, int off, int len, long timeout)
 		throws SerialException;
-		
-		public static final int NO_TERMINATE_BYTE = 0xFF00;
-		
-		public int readBytesUntil(byte [] buf, int off, int len, long timeout, int terminateByte)
-			throws SerialException;
-    
+	
+	public static final int NO_TERMINATE_BYTE = 0xFF00;
+	
+	public int readBytesUntil(byte [] buf, int off, int len, long timeout, int terminateByte)
+		throws SerialException;
+
     public void write(int value)
         throws SerialException;
     

--- a/sensor/src/main/java/org/concord/sensor/serial/SensorSerialPortRXTX.java
+++ b/sensor/src/main/java/org/concord/sensor/serial/SensorSerialPortRXTX.java
@@ -157,6 +157,10 @@ public class SensorSerialPortRXTX
 	{
 	    return port != null;
 	}
+
+	public void reset() {
+		// nothing to do
+	}
 	
 	/* (non-Javadoc)
 	 * @see org.concord.sensor.dataharvest.SerialPort#setSerialPortParams(int, int, int, int)
@@ -230,6 +234,10 @@ public class SensorSerialPortRXTX
 		} catch (UnsupportedCommOperationException e) {
 			throw new SerialException("UnsupportedCommOperation");
 		}
+	}
+
+	public void setNumChannels(int numChannels) {
+		// nothing to do
 	}
 
 	public int readBytes(byte [] buf, int off, int len, long timeout)

--- a/sensor/src/main/java/org/concord/sensor/serial/SensorSerialPortRXTX.java
+++ b/sensor/src/main/java/org/concord/sensor/serial/SensorSerialPortRXTX.java
@@ -234,6 +234,12 @@ public class SensorSerialPortRXTX
 
 	public int readBytes(byte [] buf, int off, int len, long timeout)
 		throws SerialException
+	{
+		return readBytesUntil(buf, off, len, timeout, NO_TERMINATE_BYTE);
+	}
+
+	public int readBytesUntil(byte [] buf, int off, int len, long timeout, int terminateByte)
+		throws SerialException
 	{	
 		// at least one of the receive time and theshold
 		// don't work on windows.


### PR DESCRIPTION
Corresponds to SensorConnector [PR#3](https://github.com/concord-consortium/sensor-connector/pull/3).

There's a fair amount here, but the highlights are
- add readBytesUntil() method which stops reading when a termination byte is encountered
- add support for channel polling outside of an experiment
- add additional port configuration methods (reset(), setNumChannels()) used by LabPro
- add support for device-specified delay before reading samples after starting an experiment
- updated unit tests (tested with Vernier LabPro, Go!Link, and LabQuest)

There are places in which the same stub methods were added in a number of leaf classes because there didn't seem to be a common base class in which to put them and adding one seemed like it would take me down the path of a larger refactor.

PT Story: [[151771471]](https://www.pivotaltracker.com/story/show/151771471)