### PR TITLE
First step in fixing Windows build

### DIFF
--- a/sensor-vernier/src/main/java/org/concord/sensor/vernier/labpro/LabProSensorDevice.java
+++ b/sensor-vernier/src/main/java/org/concord/sensor/vernier/labpro/LabProSensorDevice.java
@@ -176,7 +176,7 @@ public class LabProSensorDevice extends AbstractStreamingSensorDevice
 		ExperimentConfig experimentConfig = autoIdConfigure(request);
 
 		// Configure the LabPro-specific timing delay
-		experimentConfig.setInitialReadDelay(INITIAL_READ_DELAY_MILLIS);
+		((ExperimentConfigImpl) experimentConfig).setInitialReadDelay(INITIAL_READ_DELAY_MILLIS);
 
 		return experimentConfig;
 	}


### PR DESCRIPTION
Cast to ExperimentConfigImpl in call to setInitialReadDelay

Not sure why this didn't fail on the Mac build. Probably some caching issue.