### PR TITLE
pom.xml updates

### DIFF
--- a/d2pio-jna/pom.xml
+++ b/d2pio-jna/pom.xml
@@ -20,11 +20,6 @@
       <groupId>net.java.dev.jna</groupId>
       <artifactId>jna</artifactId>
     </dependency>
-    <dependency>
-      <groupId>com.nativelibs4java</groupId>
-      <artifactId>jnaerator-runtime</artifactId>
-      <version>0.12</version>
-    </dependency>
   </dependencies>
 
   <build>

--- a/pasco-jna/pom.xml
+++ b/pasco-jna/pom.xml
@@ -34,8 +34,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.7.0</version>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.6</source>
+          <target>1.6</target>
           <excludes>
             <exclude>org/concord/sensor/pasco/jna/PascoUSBDirectLibrary*</exclude>
           </excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -30,8 +30,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.7.0</version>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.6</source>
+          <target>1.6</target>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -34,11 +34,6 @@
           <target>1.6</target>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>com.nativelibs4java</groupId>
-        <artifactId>maven-jnaerator-plugin</artifactId>
-        <version>0.12</version>
-      </plugin>
     </plugins>
   </build>
 

--- a/sensor/pom.xml
+++ b/sensor/pom.xml
@@ -31,8 +31,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.7.0</version>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.6</source>
+          <target>1.6</target>
           <excludes>
             <exclude>org/concord/sensor/meld/**</exclude>
             <exclude>org/concord/sensor/transformers/**</exclude>


### PR DESCRIPTION
- Update `maven-compiler-plugin` to compile to Java 1.6 (instead of 1.5)
- Eliminate unused dependencies
